### PR TITLE
Add dataset

### DIFF
--- a/components/Filters.js
+++ b/components/Filters.js
@@ -19,6 +19,7 @@ export default function Filters(props) {
         <h5 className="mt-3 font-weight-bold text-uppercase">Filter crashes</h5>
       </Row>
       <Card className="border-0">
+        {/* buttons for mode selection */}
         <ButtonGroup className="m-1" color="primary">
           <Button
             outline
@@ -57,6 +58,28 @@ export default function Filters(props) {
             All
           </Button>
         </ButtonGroup>
+        {/* buttons for dataset selection */}
+        <ButtonGroup className="m-1" color="primary">
+          <Button
+            outline
+            color="primary"
+            onClick={() => props.dataSetChange('injury')}
+            active={props.dataSet === 'injury'}
+            className="w-50"
+          >
+            Injury
+          </Button>
+          <Button
+            outline
+            color="primary"
+            onClick={() => props.dataSetChange('fatality')}
+            active={props.dataSet === 'fatality'}
+            className="w-50"
+          >
+            Fatality
+          </Button>
+        </ButtonGroup>
+        {/* form for date selection */}
         <Form className="m-1">
           <FormGroup>
             <Label htmlFor="from" className="font-weight-bold text-uppercase">
@@ -94,4 +117,6 @@ Filters.propTypes = {
   toChange: PropTypes.func,
   modeSelection: PropTypes.string,
   modeChange: PropTypes.func,
+  dataSet: PropTypes.string,
+  dataSetChange: PropTypes.func,
 };

--- a/components/Filters.js
+++ b/components/Filters.js
@@ -63,8 +63,8 @@ export default function Filters(props) {
           <Button
             outline
             color="primary"
-            onClick={() => props.dataSetChange('crash')}
-            active={props.dataSet === 'crash'}
+            onClick={() => props.datasetChange('crash')}
+            active={props.dataset === 'crash'}
             className="w-50"
           >
             Crashes
@@ -72,8 +72,8 @@ export default function Filters(props) {
           <Button
             outline
             color="primary"
-            onClick={() => props.dataSetChange('fatality')}
-            active={props.dataSet === 'fatality'}
+            onClick={() => props.datasetChange('fatality')}
+            active={props.dataset === 'fatality'}
             className="w-50"
           >
             Fatalities
@@ -117,6 +117,6 @@ Filters.propTypes = {
   toChange: PropTypes.func,
   modeSelection: PropTypes.string,
   modeChange: PropTypes.func,
-  dataSet: PropTypes.string,
-  dataSetChange: PropTypes.func,
+  dataset: PropTypes.string,
+  datasetChange: PropTypes.func,
 };

--- a/components/Filters.js
+++ b/components/Filters.js
@@ -53,7 +53,7 @@ export default function Filters(props) {
             color="primary"
             onClick={() => props.modeChange('all')}
             active={props.modeSelection === 'all'}
-            className="w-25 font-weight-bold"
+            className="w-25"
           >
             All
           </Button>

--- a/components/Filters.js
+++ b/components/Filters.js
@@ -63,11 +63,11 @@ export default function Filters(props) {
           <Button
             outline
             color="primary"
-            onClick={() => props.dataSetChange('injury')}
-            active={props.dataSet === 'injury'}
+            onClick={() => props.dataSetChange('crash')}
+            active={props.dataSet === 'crash'}
             className="w-50"
           >
-            Injury
+            Crashes
           </Button>
           <Button
             outline
@@ -76,7 +76,7 @@ export default function Filters(props) {
             active={props.dataSet === 'fatality'}
             className="w-50"
           >
-            Fatality
+            Fatalities
           </Button>
         </ButtonGroup>
         {/* form for date selection */}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -133,7 +133,7 @@ export default class Layout extends React.Component {
                   className={`nv-s-l-a ${
                     this.props.indexPage ? 'nv-s-l-a--active' : ''
                   }`}
-                  href="/"
+                  href="."
                 >
                   View the map
                 </a>
@@ -147,6 +147,7 @@ export default class Layout extends React.Component {
                 </a>
               </li>
               <li className="nv-s-l-i">
+                {/* waiting on link to fatality open dataset */}
                 <a className="nv-s-l-a" href="">
                   Fatality data
                 </a>
@@ -156,7 +157,7 @@ export default class Layout extends React.Component {
                   className={`nv-s-l-a ${
                     this.props.aboutPage ? 'nv-s-l-a--active' : ''
                   }`}
-                  href="/about"
+                  href="about"
                 >
                   About
                 </a>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -143,7 +143,12 @@ export default class Layout extends React.Component {
                   className="nv-s-l-a"
                   href="https://data.boston.gov/dataset/vision-zero-crash-records"
                 >
-                  Download the data
+                  Crash data
+                </a>
+              </li>
+              <li className="nv-s-l-i">
+                <a className="nv-s-l-a" href="">
+                  Fatality data
                 </a>
               </li>
               <li className="nv-s-l-i">

--- a/components/Map.js
+++ b/components/Map.js
@@ -11,7 +11,7 @@ const { basemapLayer, tiledMapLayer, featureLayer } = process.browser
 const basemap_url =
   'https://awsgeo.boston.gov/arcgis/rest/services/Basemaps/BostonCityBasemap_WM/MapServer';
 
-const feature_service_url =
+const crashes_url =
   'https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/crash_cad_all_v/FeatureServer/0';
 
 const fatalities_url =
@@ -66,7 +66,7 @@ class Map extends React.Component {
 
     // Add crash feature layer
     this.crashFeatureLayer = featureLayer({
-      url: feature_service_url,
+      url: crashes_url,
       pointToLayer: function(geojson, latlng) {
         return L.marker(latlng, {
           icon: icons[geojson.properties.mode_type.toLowerCase()],

--- a/components/Map.js
+++ b/components/Map.js
@@ -145,8 +145,7 @@ class Map extends React.Component {
     if (
       this.props.modeSelection !== modeSelection ||
       this.props.fromDate !== fromDate ||
-      this.props.toDate !== toDate ||
-      this.props.dataset !== dataset
+      this.props.toDate !== toDate
     ) {
       if (modeSelection == 'all') {
         this.updateFeatures(allModesSelected, dataset);
@@ -158,8 +157,8 @@ class Map extends React.Component {
 
   // Update features when user makes new selections
   updateFeatures = (query, dataset) => {
-    // Make sure the selected dataset is added to the map, update features on
-    // other selections dataset
+    // Make sure the selected dataset is added to the map, update features based
+    // on other selections
     dataset == 'crash'
       ? this.crashFeatureLayer.addTo(this.map).setWhere(query)
       : this.fatalityFeatureLayer.addTo(this.map).setWhere(query);

--- a/components/Map.js
+++ b/components/Map.js
@@ -80,7 +80,7 @@ class Map extends React.Component {
       this.props.modeSelection,
       this.props.fromDate,
       this.props.toDate,
-      this.props.dataSet
+      this.props.dataset
     );
 
     this.crashFeatureLayer.setWhere(allModesSelected);
@@ -105,7 +105,7 @@ class Map extends React.Component {
       .addLayer(this.crashFeatureLayer);
 
     // Query for feature counts and update this.state.crashCounts
-    this.updateFeatures(allModesSelected, this.props.dataSet);
+    this.updateFeatures(allModesSelected, this.props.dataset);
 
     // Query for last updated date
     this.crashFeatureLayer
@@ -127,17 +127,17 @@ class Map extends React.Component {
   };
 
   // Update query and features when new selections are made
-  componentWillReceiveProps({ modeSelection, fromDate, toDate, dataSet }) {
+  componentWillReceiveProps({ modeSelection, fromDate, toDate, dataset }) {
     const { allModesSelected, oneModeSelected } = this.props.makeFeaturesQuery(
       modeSelection,
       fromDate,
       toDate,
-      dataSet
+      dataset
     );
 
     // If the selected dataset has changed, remove the previous one from the map
-    if (this.props.dataSet !== dataSet) {
-      dataSet == 'crash'
+    if (this.props.dataset !== dataset) {
+      dataset == 'crash'
         ? this.map.removeLayer(this.fatalityFeatureLayer)
         : this.map.removeLayer(this.crashFeatureLayer);
     }
@@ -146,21 +146,21 @@ class Map extends React.Component {
       this.props.modeSelection !== modeSelection ||
       this.props.fromDate !== fromDate ||
       this.props.toDate !== toDate ||
-      this.props.dataSet !== dataSet
+      this.props.dataset !== dataset
     ) {
       if (modeSelection == 'all') {
-        this.updateFeatures(allModesSelected, dataSet);
+        this.updateFeatures(allModesSelected, dataset);
       } else {
-        this.updateFeatures(oneModeSelected, dataSet);
+        this.updateFeatures(oneModeSelected, dataset);
       }
     }
   }
 
   // Update features when user makes new selections
-  updateFeatures = (query, dataSet) => {
+  updateFeatures = (query, dataset) => {
     // Make sure the selected dataset is added to the map, update features on
     // other selections dataset
-    dataSet == 'crash'
+    dataset == 'crash'
       ? this.crashFeatureLayer.addTo(this.map).setWhere(query)
       : this.fatalityFeatureLayer.addTo(this.map).setWhere(query);
   };
@@ -169,7 +169,7 @@ class Map extends React.Component {
   bindPopUp = (feature, layer) => {
     // Format dispatch timestamp to be readable for each dataset
     const formattedDate =
-      this.props.dataSet == 'crash'
+      this.props.dataset == 'crash'
         ? format(feature.properties.dispatch_ts, 'YYYY-MM-HH hh:mm:ss')
         : // Don't show the time on fatalities, just feels a little more respectful
           format(feature.properties.date_time, 'YYYY-MM-HH');
@@ -217,5 +217,5 @@ Map.propTypes = {
   toDate: PropTypes.string,
   modeSelection: PropTypes.string,
   makeFeaturesQuery: PropTypes.func,
-  dataSet: PropTypes.string,
+  dataset: PropTypes.string,
 };

--- a/components/Map.js
+++ b/components/Map.js
@@ -145,7 +145,8 @@ class Map extends React.Component {
     if (
       this.props.modeSelection !== modeSelection ||
       this.props.fromDate !== fromDate ||
-      this.props.toDate !== toDate
+      this.props.toDate !== toDate ||
+      this.props.dataset !== dataset
     ) {
       if (modeSelection == 'all') {
         this.updateFeatures(allModesSelected, dataset);

--- a/components/Map.js
+++ b/components/Map.js
@@ -64,8 +64,8 @@ class Map extends React.Component {
       }),
     };
 
-    // Add injury feature layer
-    this.injuryFeatureLayer = featureLayer({
+    // Add crash feature layer
+    this.crashFeatureLayer = featureLayer({
       url: feature_service_url,
       pointToLayer: function(geojson, latlng) {
         return L.marker(latlng, {
@@ -83,7 +83,7 @@ class Map extends React.Component {
       this.props.dataSet
     );
 
-    this.injuryFeatureLayer.setWhere(allModesSelected);
+    this.crashFeatureLayer.setWhere(allModesSelected);
 
     // Add fatalities feature layer to map
     this.fatalityFeatureLayer = featureLayer({
@@ -102,13 +102,13 @@ class Map extends React.Component {
     this.map
       .addLayer(basemapLayer('Gray'))
       .addLayer(tiledMapLayer({ url: basemap_url }))
-      .addLayer(this.injuryFeatureLayer);
+      .addLayer(this.crashFeatureLayer);
 
     // Query for feature counts and update this.state.crashCounts
     this.updateFeatures(allModesSelected, this.props.dataSet);
 
     // Query for last updated date
-    this.injuryFeatureLayer
+    this.crashFeatureLayer
       .query()
       .where('1=1')
       .orderBy('dispatch_ts', 'DESC')
@@ -137,9 +137,9 @@ class Map extends React.Component {
 
     // If the selected dataset has changed, remove the previous one from the map
     if (this.props.dataSet !== dataSet) {
-      dataSet == 'injury'
+      dataSet == 'crash'
         ? this.map.removeLayer(this.fatalityFeatureLayer)
-        : this.map.removeLayer(this.injuryFeatureLayer);
+        : this.map.removeLayer(this.crashFeatureLayer);
     }
 
     if (
@@ -160,8 +160,8 @@ class Map extends React.Component {
   updateFeatures = (query, dataSet) => {
     // Make sure the selected dataset is added to the map, update features on
     // other selections dataset
-    dataSet == 'injury'
-      ? this.injuryFeatureLayer.addTo(this.map).setWhere(query)
+    dataSet == 'crash'
+      ? this.crashFeatureLayer.addTo(this.map).setWhere(query)
       : this.fatalityFeatureLayer.addTo(this.map).setWhere(query);
   };
 
@@ -169,7 +169,7 @@ class Map extends React.Component {
   bindPopUp = (feature, layer) => {
     // Format dispatch timestamp to be readable for each dataset
     const formattedDate =
-      this.props.dataSet == 'injury'
+      this.props.dataSet == 'crash'
         ? format(feature.properties.dispatch_ts, 'YYYY-MM-HH hh:mm:ss')
         : // Don't show the time on fatalities, just feels a little more respectful
           format(feature.properties.date_time, 'YYYY-MM-HH');

--- a/components/MapContainer.js
+++ b/components/MapContainer.js
@@ -81,7 +81,7 @@ class MapContainer extends React.Component {
             <Legend />
           </Col>
         </Col>
-        <Col lg="9" className="p-lg-0 pr-md-4 pl-md-4">
+        <Col lg="9" className="p-lg-0 pr-md-5 pl-md-5">
           <Map
             fromDate={this.state.fromDate}
             toDate={this.state.toDate}

--- a/components/MapContainer.js
+++ b/components/MapContainer.js
@@ -13,15 +13,15 @@ class MapContainer extends React.Component {
     const { fromDate, toDate } = getDefaultDates();
     this.state = {
       modeSelection: 'all',
-      dataSet: 'crash',
+      dataset: 'crash',
       fromDate,
       toDate,
     };
   }
 
   // Update state when dataset selection changes
-  dataSetChange = dataSet => {
-    this.setState({ dataSet });
+  datasetChange = dataset => {
+    this.setState({ dataset });
   };
 
   // Update state when mode selection changes
@@ -40,9 +40,9 @@ class MapContainer extends React.Component {
   };
 
   // Select which features to add to map
-  makeFeaturesQuery = (modeSelection, fromDate, toDate, dataSet) => {
+  makeFeaturesQuery = (modeSelection, fromDate, toDate, dataset) => {
     // set date field based on selected dataset
-    const datefield = dataSet == 'crash' ? 'dispatch_ts' : 'date_time';
+    const datefield = dataset == 'crash' ? 'dispatch_ts' : 'date_time';
 
     // set query for when all modes are selected (just use dates to filter)
     const allModesSelected = `${datefield} >= 
@@ -71,8 +71,8 @@ class MapContainer extends React.Component {
             toChange={this.filterToDate}
             modeSelection={this.state.modeSelection}
             modeChange={this.filterModes}
-            dataSet={this.state.dataSet}
-            dataSetChange={this.dataSetChange}
+            dataset={this.state.dataset}
+            datasetChange={this.datasetChange}
           />
           {/* add legend twice - once for when screen is large 
             and it should display above the map, and once for when 
@@ -87,7 +87,7 @@ class MapContainer extends React.Component {
             toDate={this.state.toDate}
             modeSelection={this.state.modeSelection}
             makeFeaturesQuery={this.makeFeaturesQuery}
-            dataSet={this.state.dataSet}
+            dataset={this.state.dataset}
           />
           {/* second instance of the legend component for when 
           screen is small */}

--- a/components/MapContainer.js
+++ b/components/MapContainer.js
@@ -102,7 +102,10 @@ class MapContainer extends React.Component {
 
 export default MapContainer;
 
-// set default months - we start with 2 months ago because data is always two months behind
+// set default dates for map load data gets added
+// a few months behind, so:
+// "from" is 6 months ago
+// "to" is 4 months ago
 const getDefaultDates = () => {
   const today = new Date();
   const fourMonthsAgo = subMonths(today, 4);

--- a/components/MapContainer.js
+++ b/components/MapContainer.js
@@ -13,7 +13,7 @@ class MapContainer extends React.Component {
     const { fromDate, toDate } = getDefaultDates();
     this.state = {
       modeSelection: 'all',
-      dataSet: 'injury',
+      dataSet: 'crash',
       fromDate,
       toDate,
     };
@@ -42,7 +42,7 @@ class MapContainer extends React.Component {
   // Select which features to add to map
   makeFeaturesQuery = (modeSelection, fromDate, toDate, dataSet) => {
     // set date field based on selected dataset
-    const datefield = dataSet == 'injury' ? 'dispatch_ts' : 'date_time';
+    const datefield = dataSet == 'crash' ? 'dispatch_ts' : 'date_time';
 
     // set query for when all modes are selected (just use dates to filter)
     const allModesSelected = `${datefield} >= 

--- a/pages/about.jsx
+++ b/pages/about.jsx
@@ -27,16 +27,16 @@ export default class IndexPage extends React.Component {
               </h2>
             </a>
             <p>
-              This map and associated crash dataset, provided as part of the
-              Vision Zero Boston program, contains records of the date, time,
-              location, and type of crash for incidents requiring public safety
-              response which may involve injuries or fatalities. All records are
-              compiled by the Department of Innovation and Technology from the
-              City’s Computer-Aided Dispatch (911) system and verified as having
-              required a response from a public safety agency. To protect the
-              privacy of individuals involved in these incidents, we do not
-              indicate the severity of specific crashes or whether medical care
-              was provided in any specific case.
+              This dataset, provided as part of the Vision Zero Boston program,
+              contains records of the date, time, location, and type of crash
+              for incidents requiring public safety response which may involve
+              injuries or fatalities. All records are compiled by the Department
+              of Innovation and Technology from the City’s Computer-Aided
+              Dispatch (911) system and verified as having required a response
+              from a public safety agency. To protect the privacy of individuals
+              involved in these incidents, we do not indicate the severity of
+              specific crashes or whether medical care was provided in any
+              specific case.
             </p>
             <p>Additional notes:</p>
             <ul

--- a/pages/about.jsx
+++ b/pages/about.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Layout from '../components/Layout';
 import { Col } from 'reactstrap';
 
-export default class IndexPage extends React.Component {
+export default class AboutPage extends React.Component {
   render() {
     return (
       <div>

--- a/pages/about.jsx
+++ b/pages/about.jsx
@@ -18,49 +18,70 @@ export default class IndexPage extends React.Component {
               2030. We are inspired by the belief that even one fatality is too
               many.
             </p>
+            <a href="https://data.boston.gov/dataset/vision-zero-crash-records">
+              <h2
+                className="pt-2"
+                style={{ fontFamily: 'Lora', fontStyle: 'italic' }}
+              >
+                Crash Data
+              </h2>
+            </a>
             <p>
-              This map and associated dataset, provided as part of the Vision
-              Zero Boston program, contains records of the date, time, location,
-              and type of crash for incidents requiring public safety response
-              which may involve injuries or fatalities. All records are compiled
-              by the Department of Innovation and Technology from the City’s
-              Computer-Aided Dispatch (911) system and verified as having
+              This map and associated crash dataset, provided as part of the
+              Vision Zero Boston program, contains records of the date, time,
+              location, and type of crash for incidents requiring public safety
+              response which may involve injuries or fatalities. All records are
+              compiled by the Department of Innovation and Technology from the
+              City’s Computer-Aided Dispatch (911) system and verified as having
               required a response from a public safety agency. To protect the
               privacy of individuals involved in these incidents, we do not
               indicate the severity of specific crashes or whether medical care
               was provided in any specific case.
             </p>
-            <p>
-              Additional notes:
-              <ul>
-                <li>
-                  Each incident is included only once regardless of the number
-                  of individuals involved.
-                </li>
-                <li>
-                  The date and time of an incident reflects when public safety
-                  response was dispatched to the location, not the crash itself.
-                </li>
-                <li>
-                  Records are typically updated on a monthly basis, but because
-                  the verification process involves manual confirmation of
-                  incidents, exact posting schedules may vary.
-                </li>
-                <li>
-                  Records may be updated after their initial posting if new
-                  information becomes available.
-                </li>
-              </ul>
-            </p>
+            <p>Additional notes:</p>
+            <ul
+              style={{
+                fontFamily: 'Lora',
+                fontSize: '18px',
+              }}
+            >
+              <li>
+                Each incident is included only once regardless of the number of
+                individuals involved.
+              </li>
+              <li>
+                The date and time of an incident reflects when public safety
+                response was dispatched to the location, not the crash itself.
+              </li>
+              <li>
+                Records are typically updated on a monthly basis, but because
+                the verification process involves manual confirmation of
+                incidents, exact posting schedules may vary.
+              </li>
+              <li>
+                Records may be updated after their initial posting if new
+                information becomes available.
+              </li>
+            </ul>
 
-            <p>
+            <a href="">
+              <h2
+                className="pt-2"
+                style={{ fontFamily: 'Lora', fontStyle: 'italic' }}
+              >
+                Fatality Data
+              </h2>
+            </a>
+            <p>Placeholder fatality data text.</p>
+
+            <p style={{ fontStyle: 'italic' }}>
               Please note that the data and information on this website is for
               informational purposes only. While we seek to provide accurate
-              information, please note that errors may be present and
-              information presented may not be complete. Accordingly, the City
-              of Boston makes no representation as to the accuracy of the
-              information or its suitability for any purpose and disclaim any
-              liability for omissions or errors that may be contained therein.
+              information, note that errors may be present and information
+              presented may not be complete. Accordingly, the City of Boston
+              makes no representation as to the accuracy of the information or
+              its suitability for any purpose and disclaim any liability for
+              omissions or errors that may be contained therein.
             </p>
           </Col>
         </Layout>


### PR DESCRIPTION
This PR:
- adds the ability to view fatality data - gives users to see either the fatality data or crash data (not at the same time)
- makes sure users can filter the fatality data by mode type and date 
- changes the default date calculation to leverage date-fns and sets it back more months to future proof ourselves
- adds placeholder links for finding the fatality data and placeholder text for explaining it (waiting on final approval and posting)