### PR TITLE
Adding feature counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Vision Zero Crash Map
+
+This repo houses code for Boston's [vision zero crash map](apps.boston.gov/vision-zero). The data displayed
+on the map can be found on the City's open data portal, under [vision zero crash records](https://data.boston.gov/dataset/vision-zero-crash-records)
+and [vision zero fatality records](https://data.boston.gov/dataset/vision-zero-fatality-records).
+
+## Built with
+- [React](https://reactjs.org/)
+- [Next.js](https://nextjs.org/)
+- [leaflet](https://leafletjs.com/)
+- [esri-leaflet](https://esri.github.io/esri-leaflet/)

--- a/components/FeatureCounts.js
+++ b/components/FeatureCounts.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Row, Col } from 'reactstrap';
+
+export default function FeatureCounts(props) {
+  return (
+    <Row>
+      <Col sm="12" md="3" style={{ opacity: 0.9 }}>
+        <div className="bg-light m-0 p-2">
+          <div className="p-2">
+            <h5 className="m-0 font-weight-bold text-uppercase">
+              Citywide Totals
+            </h5>
+            <hr className="m-1" />
+            <h6 className="mt-2 font-italic">
+              {props.mode} {props.dataset}: {props.pointCount}
+            </h6>
+            <p className="mt-2 mb-0 font-italic" style={{ fontSize: '.8rem' }}>
+              {props.fromDate} to {props.toDate}
+            </p>
+          </div>
+        </div>
+      </Col>
+    </Row>
+  );
+}
+
+FeatureCounts.propTypes = {
+  pointCount: PropTypes.number,
+  mode: PropTypes.string,
+  dataset: PropTypes.string,
+  toDate: PropTypes.string,
+  fromDate: PropTypes.string,
+};

--- a/components/Map.js
+++ b/components/Map.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
+import FeatureCounts from './FeatureCounts';
 
 // We can't import these server-side because they require "window"
 const L = process.browser ? require('leaflet') : null;
@@ -22,6 +23,7 @@ class Map extends React.Component {
     super(props);
 
     this.state = {
+      pointCount: 0,
       lastUpdatedDate: '',
     };
   }
@@ -51,15 +53,15 @@ class Map extends React.Component {
     const icons = {
       ped: new L.Icon({
         iconUrl: './static/marker-11-red.svg',
-        iconSize: [30, 30],
+        iconSize: [25, 25],
       }),
       mv: new L.Icon({
         iconUrl: './static/marker-11-blue.svg',
-        iconSize: [30, 30],
+        iconSize: [25, 25],
       }),
       bike: new L.Icon({
         iconUrl: './static/marker-11-yellow.svg',
-        iconSize: [30, 30],
+        iconSize: [25, 25],
       }),
     };
 
@@ -161,11 +163,23 @@ class Map extends React.Component {
 
   // Update features when user makes new selections
   updateFeatures = (query, dataset) => {
-    // Make sure the selected dataset is added to the map, update features based
-    // on other selections
-    dataset == 'crash'
-      ? this.crashFeatureLayer.addTo(this.map).setWhere(query)
-      : this.fatalityFeatureLayer.addTo(this.map).setWhere(query);
+    // Set the featureLayer to update based on the selected dataset
+    const selectedData =
+      dataset == 'crash' ? this.crashFeatureLayer : this.fatalityFeatureLayer;
+
+    selectedData
+      // Add the selected dataset to the map
+      .addTo(this.map)
+      // Only show points that match the user's selections
+      .setWhere(query)
+      // Query the layer based on the users selections and
+      // return a list of feature ids
+      .query()
+      .where(query)
+      .ids((error, ids) => {
+        // Use the length of the returned list to update pointCount
+        this.setState({ pointCount: ids.length });
+      });
   };
 
   // Set popup for features
@@ -195,6 +209,29 @@ class Map extends React.Component {
     layer.bindPopup(popupContent);
   };
 
+  // Make mode selection nicer for displaying in FeatureCounts
+  formatModeSelection = modeSelection => {
+    if (modeSelection == 'all') {
+      return 'All';
+    } else if (modeSelection == 'bike') {
+      return 'Bike';
+    } else if (modeSelection == 'mv') {
+      return 'Motor vehicle';
+    } else {
+      return 'Pedestrian';
+    }
+  };
+
+  // Make dataset selection nicer for displaying in FeatureCounts
+  formatDataSelection = dataSelection => {
+    return dataSelection == 'crash' ? 'crashes' : 'fatalities';
+  };
+
+  // Make selected dates nicer for displaying in FeatureCounts
+  formatDate = date => {
+    return format(date, 'MM/D/YY');
+  };
+
   render() {
     return (
       <div>
@@ -202,8 +239,20 @@ class Map extends React.Component {
         <div
           style={{ height: 'calc(100vh - 125px)' }}
           ref={this.setMapEl}
-          lastUpdated={this.state.lastUpdatedDate}
-        />
+          lastupdated={this.state.lastUpdatedDate}
+        >
+          <div
+            style={{ zIndex: 1000, position: 'relative', fontFamily: 'Lora' }}
+          >
+            <FeatureCounts
+              pointCount={this.state.pointCount}
+              mode={this.formatModeSelection(this.props.modeSelection)}
+              dataset={this.formatDataSelection(this.props.dataset)}
+              toDate={this.formatDate(this.props.toDate)}
+              fromDate={this.formatDate(this.props.fromDate)}
+            />
+          </div>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
This PR:
- adds feature counts back to the map 
     - They are implemented a little bit differently than they previously were due to the old counts not displaying correctly when >4000. Now we query the layer after updating its display and return a list of feature ids. The length of that list populates the feature count (this.state.pointCount)
- adds a few functions that format the modeSelection, dates, and dataset selection so they are nicer to display in the feature counts
- makes the icons a little smaller as requested by the stakeholders
- adds a readme
