### PR TITLE
Times on date queries

### DIFF
--- a/components/Map.js
+++ b/components/Map.js
@@ -402,14 +402,32 @@ class Map extends React.Component {
 
     // Set the filters for the dates - using the time field for each dataset
     // and a unix timestamp of the selected date
+    // We are explict about times so that users can filter for one day and still
+    // get proper results.
     const fromDateFilter =
       dataset == 'crash'
-        ? ['>=', ['number', ['get', 'dispatch_ts']], getTime(fromDate)]
-        : ['>=', ['number', ['get', 'date_time']], getTime(fromDate)];
+        ? [
+            '>=',
+            ['number', ['get', 'dispatch_ts']],
+            getTime(`${fromDate} 00:00:00`),
+          ]
+        : [
+            '>=',
+            ['number', ['get', 'date_time']],
+            getTime(`${fromDate} 00:00:00`),
+          ];
     const toDateFilter =
       dataset == 'crash'
-        ? ['<=', ['number', ['get', 'dispatch_ts']], getTime(toDate)]
-        : ['<=', ['number', ['get', 'date_time']], getTime(toDate)];
+        ? [
+            '<=',
+            ['number', ['get', 'dispatch_ts']],
+            getTime(`${toDate} 11:59:59`),
+          ]
+        : [
+            '<=',
+            ['number', ['get', 'date_time']],
+            getTime(`${toDate} 11:59:59`),
+          ];
 
     // We use makeFeaturesQuery and updatePointCount to update the total crashes/fatalities
     // shown on the map. We still use esri-leaflet for this because there currently isn't a

--- a/components/MapContainer.js
+++ b/components/MapContainer.js
@@ -50,11 +50,10 @@ class MapContainer extends React.Component {
     // set date field based on selected dataset
     const datefield = dataset == 'crash' ? 'dispatch_ts' : 'date_time';
 
-    // Here we deal with timezones - we set the filter hours to always be
-    // at 5am for the selected day so things look right to us here on the
-    // east coast (except for during daylight savings).
-    const fromDateWithTimeZone = `${fromDate} 05:00:00`;
-    const toDateWithTimeZone = `${toDate} 05:00:00`;
+    // We have to be explcit about times on fromDate and toDate so that
+    // users can query just one day and still get results.
+    const fromDateWithTimeZone = `${fromDate} 00:00:00`;
+    const toDateWithTimeZone = `${toDate} 11:59:59`;
 
     // set query for when all modes are selected (just use dates to filter)
     const allModesSelected = `${datefield} >= 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1587,9 +1587,9 @@
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "bootstrap": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.1.tgz",
-      "integrity": "sha512-SpiDSOcbg4J/PjVSt4ny5eY6j74VbVSjROY4Fb/WIUXBV9cnb5luyR4KnPvNoXuGnBK1T+nJIWqRsvU3yP8Mcg=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
+      "integrity": "sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w=="
     },
     "brace-expansion": {
       "version": "1.1.11",


### PR DESCRIPTION
This PR:
- adds times to date queries so a user can successfully query for one day 
     - we replace the "5am" times we were previously using to account for timezones since setting a specific timezone when loading data into ArcGIS seems to work. Instead we use 12am to 'fromDate' and 11:59pm to 'toDate' so users can successfully query for one day
- updates bootstrap dependency to remove vulnerability in package-lock.json
