### PR TITLE
Only load 5 years of data

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -107,7 +107,7 @@ export default class Layout extends React.Component {
                     className="lo-i"
                   />
                 </a>
-                <span className="lo-t">Mayor Kim Janey</span>
+                <span className="lo-t">Mayor Michelle Wu</span>
               </div>
             </div>
           </Navbar>

--- a/components/Map.js
+++ b/components/Map.js
@@ -83,12 +83,12 @@ class Map extends React.Component {
       // We add the crashes and fatalities layers as geojson
       this.map.addSource('crashes', {
         type: 'geojson',
-        data: `${crashes_url}/query?where=dispatch_ts>'${this.props.dataLoadedAsOf}'&outFields=*&outSR=4326&returnExceededLimitFeatures=true&f=pgeojson`,
+        data: `${crashes_url}/query?where=dispatch_ts>='${this.props.dataLoadedAsOf}'&outFields=*&outSR=4326&returnExceededLimitFeatures=true&f=pgeojson`,
       });
 
       this.map.addSource('fatalities', {
         type: 'geojson',
-        data: `${fatalities_url}/query?where=date_time>'${this.props.dataLoadedAsOf}'&outFields=*&outSR=4326&returnExceededLimitFeatures=true&f=pgeojson`,
+        data: `${fatalities_url}/query?where=date_time>='${this.props.dataLoadedAsOf}'&outFields=*&outSR=4326&returnExceededLimitFeatures=true&f=pgeojson`,
       });
 
       // We want the map to show points at higher zoom levels and

--- a/components/Map.js
+++ b/components/Map.js
@@ -83,12 +83,12 @@ class Map extends React.Component {
       // We add the crashes and fatalities layers as geojson
       this.map.addSource('crashes', {
         type: 'geojson',
-        data: `${crashes_url}/query?where=1%3D1&outFields=*&outSR=4326&returnExceededLimitFeatures=true&f=pgeojson`,
+        data: `${crashes_url}/query?where=dispatch_ts>'${this.props.dataLoadedAsOf}'&outFields=*&outSR=4326&returnExceededLimitFeatures=true&f=pgeojson`,
       });
 
       this.map.addSource('fatalities', {
         type: 'geojson',
-        data: `${fatalities_url}/query?where=1%3D1&outFields=*&outSR=4326&returnExceededLimitFeatures=true&f=pgeojson`,
+        data: `${fatalities_url}/query?where=date_time>'${this.props.dataLoadedAsOf}'&outFields=*&outSR=4326&returnExceededLimitFeatures=true&f=pgeojson`,
       });
 
       // We want the map to show points at higher zoom levels and
@@ -375,7 +375,12 @@ class Map extends React.Component {
     });
   }
 
-  componentWillReceiveProps({ modeSelection, fromDate, toDate, dataset }) {
+  UNSAFE_componentWillReceiveProps({
+    modeSelection,
+    fromDate,
+    toDate,
+    dataset,
+  }) {
     // If the selected dataset is 'crash', we make sure the crashes layers are
     // visible and the fatalities are not. If the selected dataset is
     // 'fatalities', we do the opposite.
@@ -560,4 +565,5 @@ Map.propTypes = {
   makeFeaturesQuery: PropTypes.func,
   dataset: PropTypes.string,
   updateDate: PropTypes.func,
+  dataLoadedAsOf: PropTypes.string,
 };

--- a/components/MapContainer.js
+++ b/components/MapContainer.js
@@ -11,12 +11,14 @@ class MapContainer extends React.Component {
 
     // get default dates to set
     const { fromDate, toDate } = getDefaultDates();
+    const dataLoadedAsOf = getFiveYearsAgo();
     this.state = {
       modeSelection: 'all',
       dataset: 'crash',
       fromDate,
       toDate,
       updatedDate: '',
+      dataLoadedAsOf,
     };
   }
 
@@ -96,7 +98,8 @@ class MapContainer extends React.Component {
             datasetChange={this.datasetChange}
           />{' '}
           <p className="font-italic ml-1">
-            Data updated as of the last day of: {this.state.updatedDate}{' '}
+            Data from {format(this.state.dataLoadedAsOf, 'MM/DD/YYYY')} to the
+            last day of {this.state.updatedDate} can be displayed on the map.{' '}
           </p>{' '}
           {/* add legend twice - once for when screen is large screen is small and it should display below the map */}{' '}
           <Col className="p-0 d-none d-lg-block">
@@ -111,6 +114,7 @@ class MapContainer extends React.Component {
             dataset={this.state.dataset}
             makeFeaturesQuery={this.makeFeaturesQuery}
             updateDate={this.setLastUpdatedDate}
+            dataLoadedAsOf={this.state.dataLoadedAsOf}
           />{' '}
           {/* second instance of the legend component for when screen is small */}{' '}
           <Col className="d-sm-block d-md-block d-lg-none pl-0">
@@ -138,4 +142,9 @@ const getDefaultDates = () => {
     fromDate: from,
     toDate: to,
   };
+};
+
+const getFiveYearsAgo = () => {
+  const fiveYearsAgo = getYear(new Date()) - 5;
+  return `${fiveYearsAgo}-01-01`;
 };


### PR DESCRIPTION
This PR changes the Vision Zero Map to only load and display the last five years of data. 

**Bug:** The map currently shows no data on initial load despite the count in the upper left indicating there are 779 crashes during this time frame.
<img width="1310" alt="Screen Shot 2023-04-30 at 12 39 14 PM" src="https://user-images.githubusercontent.com/12868231/235365092-1a16f087-6d0e-4130-a162-62f1dc0a76f8.png">

**Likely cause:** The crashes feature layer's `Max Record Count` is set to 32000 and the map is trying to load every feature in it, but the feature layer currently has 33054 features in it. When the data is loaded, the last 1054 features are missing and do not display on the map.
<img width="602" alt="Screen Shot 2023-04-30 at 12 40 15 PM" src="https://user-images.githubusercontent.com/12868231/235365182-56bcea66-9991-43a0-af07-a28fb17bd440.png">

**Fix:** This PR makes the map dynamically load the last five years of data (20057 features currently) instead of trying to load everything (data goes back to 2014). Map on load with fix:
<img width="1306" alt="Screen Shot 2023-04-30 at 12 44 21 PM" src="https://user-images.githubusercontent.com/12868231/235365337-be699e7e-dddc-4627-99d2-1ae8f4aa57ce.png">

